### PR TITLE
Add progressbar as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="librec-auto",
     version="0.1.27",
-	scripts=['core\__main__.py'] ,
+    scripts=['core\__main__.py'] ,
     author="Masoud Mansoury and Robin Burke",
     author_email="masoodmansoury@gmail.com",
     description="The librec-auto project aims to automate recommender system experimens using LibRec.",
@@ -14,13 +14,13 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/that-recsys-lab/librec-auto",
     packages=setuptools.find_packages(),
-	include_package_data=True,
-	install_requires=[
-          'matplotlib',
-		  'pandas',
-		  'numpy',		  
+    include_package_data=True,
+    install_requires=[
+        'matplotlib',
+        'pandas',
+        'numpy',
     ],
-	classifiers=[
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     install_requires=[
         'matplotlib',
         'pandas',
+        'progressbar',
         'numpy',
     ],
     classifiers=[


### PR DESCRIPTION
`progressbar` is currently required to run, but missing from the dependencies

Here's a stack trace:
```
andrew@AS:~$ python3 -m librec_auto install
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/andrew/.local/lib/python3.8/site-packages/librec_auto/__main__.py", line 5, in <module>
    from librec_auto.core.cmd import Cmd, SetupCmd, SequenceCmd, PurgeCmd, LibrecCmd, PostCmd, RerankCmd, StatusCmd, ParallelCmd, InstallCmd
  File "/home/andrew/.local/lib/python3.8/site-packages/librec_auto/core/cmd/__init__.py", line 10, in <module>
    from .install_cmd import InstallCmd
  File "/home/andrew/.local/lib/python3.8/site-packages/librec_auto/core/cmd/install_cmd.py", line 8, in <module>
    import progressbar
ModuleNotFoundError: No module named 'progressbar'
```