### PR TITLE
Added link to description in '--help'

### DIFF
--- a/librec_auto/__main__.py
+++ b/librec_auto/__main__.py
@@ -13,7 +13,7 @@ def read_args():
     '''
     parser = argparse.ArgumentParser(
         description=
-        'The librec-auto tool for running recommender systems experiments')
+        'The librec-auto tool for running recommender systems experiments. TODO- This is a work in progress. For now, refer to this link: https://librec-auto.readthedocs.io/en/latest/')
     parser.add_argument('action',
                         choices=[
                             'run', 'split', 'eval', 'rerank', 'post', 'purge',
@@ -239,3 +239,4 @@ if __name__ == '__main__':
                 logging.error("Command instantiation failed.")
         else:
             logging.error("Configuration loading failed.")
+


### PR DESCRIPTION
I've added a link to the read the docs in the description for the flags. Once the docs are more updated, I intend to add more specific flags for help.