### PR TITLE
empty header deleted

### DIFF
--- a/librec_auto/docs/source/howtos.rst
+++ b/librec_auto/docs/source/howtos.rst
@@ -74,6 +74,3 @@ In order to use this script, you will need to add it to the post-processing port
 
 The plots are stored in the ``post`` directory under the names ``viz-bar-`` *metric*.jpg and ``viz-box-`` *metric*.jpg where *metric*
 is the name of the LibRec metric that was calculated.
-
-How to check your configuration files for errors
--------------------------


### PR DESCRIPTION
removed "how to check ... config ..." from "How-Tos" page